### PR TITLE
Fix SPM warning on Xcode 12 and 13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,6 @@ import PackageDescription
 
 let package = Package(
     name: "FCUUID",
-    platforms: [.iOS(.v8)],
     products: [
         .library(
             name: "FCUUID",


### PR DESCRIPTION
Unlike CocoaPods, SPM platforms only specify minimum supported deployment targets, and does not prevent compiling package on macOS for example.

When using package on Xcode 13, SPM shows a warning: 

`FCUUID/Package.swift The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 15.2.99.`

By removing platforms from Package.swift this warning will go away, since now Xcode is in charge of what platforms are supported, and automatically sets minimum deployment target for this package(which, on Xcode 13, is iOS 9).

This does not drop support for iOS 8, as support for iOS 8 was already dropped by Xcode 12, this change only removes a warning.